### PR TITLE
Follow the 'connections' uri when present

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 Flask==1.1.1
-itsdangerous==0.24
 click==6.7

--- a/templates/main.html
+++ b/templates/main.html
@@ -113,7 +113,7 @@
             <div class="grid-item">
                 <label id="urlLabel" for="url"> Simple API Invoke With Token:</label>
                 <input type="url" id="url" name="url" aria-label="urlLabel"
-                       value="https://sandboxapi.deere.com/platform/organizations"/>
+                       value={{settings.apiUrl}}/organizations/>
             </div>
             <div class="grid-item">
                 <input type="submit" value="Go!">


### PR DESCRIPTION
* Full access to the API requires both user consent and designating
which organizations the user wants the application to be able to
interact with. Follow the 'connections' uri if present on any org to
allow the user finish the setup process.
* Remove `itsdangerous` dependency. Appears unused.