### PR TITLE
Add the 'redirect_uri'.

### DIFF
--- a/john-deere-api.py
+++ b/john-deere-api.py
@@ -99,7 +99,8 @@ def needs_organization_access():
         for link in org['links']:
             if link['rel'] == 'connections':
                 connectionsUri = link['uri']
-                return '%s?%s' % (connectionsUri, urllib.parse.urlencode({'redirect_uri': settings['orgConnectionCompletedUrl']}))
+                query = urllib.parse.urlencode({'redirect_uri': settings['orgConnectionCompletedUrl']})
+                return f"{connectionsUri}?{query}"
     return None
 
 @app.route("/callback")

--- a/john-deere-api.py
+++ b/john-deere-api.py
@@ -10,13 +10,15 @@ import urllib.parse
 
 app = Flask(__name__)
 
+SERVER_URL='http://localhost:9090'
+
 settings = {
     'apiUrl': 'https://sandboxapi.deere.com/platform',
     'clientId': '',
     'clientSecret': '',
     'wellKnown': 'https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/.well-known/oauth-authorization-server',
-    'callbackUrl': 'http://localhost:9090/callback',
-    'orgConnectionCompletedUrl': 'http://localhost:9090/',
+    'callbackUrl': f"{SERVER_URL}/callback",
+    'orgConnectionCompletedUrl': SERVER_URL,
     'scopes': 'ag1 ag2 ag3 eq1 eq2 org1 org2 files offline_access',
     'state': uuid.uuid1(),
     'idToken': '',

--- a/john-deere-api.py
+++ b/john-deere-api.py
@@ -16,6 +16,7 @@ settings = {
     'clientSecret': '',
     'wellKnown': 'https://signin.johndeere.com/oauth2/aus78tnlaysMraFhC1t7/.well-known/oauth-authorization-server',
     'callbackUrl': 'http://localhost:9090/callback',
+    'orgConnectionCompletedUrl': 'http://localhost:9090/',
     'scopes': 'ag1 ag2 ag3 eq1 eq2 org1 org2 files offline_access',
     'state': uuid.uuid1(),
     'idToken': '',
@@ -97,7 +98,8 @@ def needs_organization_access():
     for org in api_response['values']:
         for link in org['links']:
             if link['rel'] == 'connections':
-                return link['uri']
+                connectionsUri = link['uri']
+                return '%s?%s' % (connectionsUri, urllib.parse.urlencode({'redirect_uri': settings['orgConnectionCompletedUrl']}))
     return None
 
 @app.route("/callback")


### PR DESCRIPTION
* The connections app knows how to issue a redirct when the
select-organization is called with a redirect_uri query parameter.
This can send the user back the original app once they have completed
the organization selection process and makes exercising the api through
the demo app smoother.